### PR TITLE
Feature: Add V2 API endpoints to support client operations.

### DIFF
--- a/index.js
+++ b/index.js
@@ -304,6 +304,10 @@ module.exports = function(app) {
   plugin.name = "Buddy List"
   plugin.description = "Provides a buddy list for Signal K Node Server"
 
+  plugin.feature = "buddies"
+  plugin.getOpenApi = () => require('./openApi.json')
+  plugin.registerWithRouter = () => {}
+
   plugin.schema = {
     type: "object",
     properties: {

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@
 const geolib = require('geolib')
 
 const apiBase = '/signalk/v1/api/resources/buddies'
+const v2ApiBase = '/signalk/v2/api/resources/buddies'
 
 module.exports = function(app) {
   var plugin = {};
@@ -24,10 +25,19 @@ module.exports = function(app) {
 
   plugin.start = function(props) {
     setupSubscriptions(props)
-    
+
     app.get(apiBase, (req, res) => {
       const list = (props.buddies || []).map(buddy => {
         return JSON.parse(JSON.stringify(buddy))
+      })
+      res.json(list)
+    })
+
+    app.get(v2ApiBase, (req, res) => {
+      const buddies = (Array.isArray(props.buddies) ? props.buddies : [])
+      const list = {}
+      buddies.forEach( buddy => {
+        list[buddy.urn] = {name: buddy.name}
       })
       res.json(list)
     })
@@ -46,6 +56,27 @@ module.exports = function(app) {
 
       props.buddies.push(req.body)
       saveConfig(props, res)
+    })
+
+    app.post(v2ApiBase, (req, res) => {
+      if ( typeof req.body.urn === 'undefined' ) {
+        res.status(400).json({
+          "state": "FAILED",
+          "statusCode": 400,
+          "message": "Please include a urn!"
+        })
+        return
+      }
+      if ( props.buddies.find(b => b.urn === req.body.urn ) ) {
+        res.status(400).json({
+          "state": "FAILED",
+          "statusCode": 400,
+          "message": "Buddy already exists!"
+        })
+        return
+      }
+      props.buddies.push(req.body)
+      saveConfigV2(props, res)
     })
 
     app.delete(apiBase + '/:urn', (req, res) => {
@@ -70,6 +101,30 @@ module.exports = function(app) {
       })
     })
 
+    app.delete(v2ApiBase + '/:urn', (req, res) => {
+      if ( !props.buddies.find(b => b.urn === req.params.urn) ) {
+        res.status(404).json({
+          "state": "FAILED",
+          "statusCode": 404,
+          "message": `Cannot find buddy with urn: ${req.params.urn}`
+        })
+        return
+      }
+      
+      props.buddies = props.buddies.filter(b => b.urn !== req.params.urn)
+      saveConfigV2(props, res)
+
+      app.handleMessage(plugin.id, {
+        context: `vessels.${req.params.urn}`,
+        updates: [{
+          values: [{
+            path: '',
+            value: { buddy: false }
+          }]
+        }]
+      })
+    })
+
     app.put(apiBase + '/:urn', (req, res) => {
       const urn = req.params.urn
       const buddy = props.buddiesfind(b => b.urn == urn)
@@ -81,6 +136,48 @@ module.exports = function(app) {
 
       buddy.name = req.body.name
       saveConfig(props, res)
+    })
+
+    app.put(v2ApiBase + '/:urn', (req, res) => {
+      const buddy = props.buddies.find(b => b.urn === req.params.urn )
+      if ( !buddy ) {
+        res.status(404).json({
+          "state": "FAILED",
+          "statusCode": 404,
+          "message": `Cannot find buddy with urn: ${req.params.urn}`
+        })
+        return
+      }
+      if ( typeof req.body.name === 'undefined' ) {
+        res.status(400).json({
+          "state": "FAILED",
+          "statusCode": 400,
+          "message": "Please include a name!"
+        })
+        return
+      }
+      buddy.name = req.body.name
+      saveConfigV2(props, res)
+    })
+  }
+
+  function saveConfigV2(props, res) {
+    app.savePluginOptions(props, err => {
+      if ( err ) {
+        res.status(404).json({
+          "state": "FAILED",
+          "statusCode": 400,
+          "message": "unable to save buddies!"
+        })
+      } else {
+        res.json({
+          "state": "COMPLETED",
+          "statusCode": 200,
+          "message": "Buddies saved!"
+        })
+        stopSuscriptions()
+        setupSubscriptions(props)
+      }
     })
   }
 

--- a/openApi.json
+++ b/openApi.json
@@ -1,0 +1,211 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "2.0.0",
+    "title": "Buddy API",
+    "termsOfService": "http://signalk.org/terms/",
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "externalDocs": {
+    "url": "http://signalk.org/specification/",
+    "description": "Signal K specification."
+  },
+  "servers": [
+    {
+      "url": "/signalk/v2/api/resources/buddies"
+    }
+  ],
+  "tags": [
+    {
+      "name": "buddies",
+      "description": "Buddy operations"
+    }
+  ],
+  "components": {
+    "schemas": {},
+    "responses": {
+      "200Ok": {
+        "description": "OK",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "state": {
+                  "type": "string",
+                  "enum": ["COMPLETED"]
+                },
+                "statusCode": {
+                  "type": "number",
+                  "enum": [200]
+                }
+              },
+              "required": ["state", "statusCode"]
+            }
+          }
+        }
+      },
+      "ErrorResponse": {
+        "description": "Failed operation",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "description": "Request error response",
+              "properties": {
+                "state": {
+                  "type": "string",
+                  "enum": ["FAILED"]
+                },
+                "statusCode": {
+                  "type": "number",
+                  "enum": [400]
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "required": ["state", "statusCode", "message"]
+            }
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
+      },
+      "cookieAuth": {
+        "type": "apiKey",
+        "in": "cookie",
+        "name": "JAUTHENTICATION"
+      }
+    }
+  },
+  "security": [{ "cookieAuth": [] }, { "bearerAuth": [] }],
+  "paths": {
+    "/": {
+      "get": {
+        "tags": ["buddies"],
+        "summary": "Retrieve list of buddies.",
+        "description": "Returns a list of buddies indexed by their urn.",
+        "responses": {
+          "default": {
+            "description": "Data from weather station that weather proivder deems closest to the vessel position.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "example": "urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021f"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": ["buddies"],
+        "summary": "Add a buddy.",
+        "description": "Add a buddy by providing the vessel `urn` and a friendly `name`.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["name","urn"],
+                "properties": {
+                  "urn": {
+                    "type": "string",
+                    "description": "Vessel urn"
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "Vessel name"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/200Ok"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
+          }
+        }
+      }
+    },
+    "/{urn}": {
+      "parameters": [
+        {
+          "name": "urn",
+          "in": "path",
+          "description": "Buddy vessel `urn`",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "put": {
+        "tags": ["buddies"],
+        "summary": "Update buddy vessel friendly `name`.",
+        "description": "Updates the `name` assigned to an identified buddy vessel.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["name"],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Vessel name"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/200Ok"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
+          }
+        }
+      },
+      "delete": {
+        "tags": ["buddies"],
+        "summary": "Remove vessel from buddy list.",
+        "description": "Remove the vessel with the supplied urn from the buddy list.",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/200Ok"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Endpoints created under `/signalk/v2/api/resources/buddies` to:
- return buddy list
- add buddy
- update buddy name
- remove buddy

Added OpenAPI definition for V2 endpoints.

Note: Added separate functions for all V2 endpoint processing and have not changed the v1 endpoint handling or responses so as not to cause breaking changes.

